### PR TITLE
VBE Switch on GRUB

### DIFF
--- a/grub/stage2/common.c
+++ b/grub/stage2/common.c
@@ -33,6 +33,13 @@ struct multiboot_info mbi;
 unsigned long saved_drive;
 unsigned long saved_partition;
 unsigned long cdrom_drive;
+
+/*
+ *  VBE Info
+ */
+struct vbe_mode mbi_vbe_mode;
+struct vbe_controller mbi_vbe_controller;
+
 #ifndef STAGE1_5
 unsigned long saved_mem_upper;
 

--- a/grub/stage2/shared.h
+++ b/grub/stage2/shared.h
@@ -674,6 +674,13 @@ extern struct multiboot_info mbi;
 extern unsigned long saved_drive;
 extern unsigned long saved_partition;
 extern unsigned long cdrom_drive;
+
+/*
+ *  VBE Info
+ */
+extern struct vbe_mode mbi_vbe_mode;
+extern struct vbe_controller mbi_vbe_controller;
+
 #ifndef STAGE1_5
 extern unsigned long saved_mem_upper;
 extern unsigned long extended_memory;


### PR DESCRIPTION
With this pull request GRUB will be able to carry out the exchange between the video modes supported by VESA BIOS Extension before booting a kernel compatible with multiboot.

For this purpose, has been added the 'vbemode' command, that can be executed from the command line or by script (menu.lst e.g.) and receives as a parameter the resolution and color depth desired, for example: `vbemode 800x600x32`.

If the resolution is not supported, GRUB will attempt to locate the nearest and lower resolution than the informed and which have the same color depth. If still not possible (no one other lower resolution with the same bpp) GRUB will keep mode 80x25.

Fields of multiboot_info:
- flags
- vbe_mode
- vbe_mode_info
- vbe_control_info

They are updated, so you can count on them when your kernel boot and you should be able to see in which mode is by checking the flag `MB_INFO_VIDEO_INFO` and the pointer `vbe_mode_info` structure that contains the current video mode data.
